### PR TITLE
fix: consolidate security dependency minimums

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Raised minimum dependency versions to address historical Snyk advisories for `setuptools`,
+  `dnspython`, `numpy`, and `zipp`.
+
 ## [1.6.0] - 2026-07-22
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=65.5.0", "wheel"]
+requires = ["setuptools>=70.0.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -31,12 +31,14 @@ classifiers = [
 dependencies = [
     "avro>=1.10.2",
     "chardet>=5.2.0",
+    "dnspython>=2.6.1",
     "duckdb",
     "elasticsearch",
     "iterabledata",
     "jsonlines>=4.0.0",
     "lz4>=4.3.2",
     "mistql>=0.4.11",
+    "numpy>=1.22.2",
     "openpyxl>=3.1.2",
     "orjson>=3.9.8",
     "pandas>=2.0.3",
@@ -59,6 +61,7 @@ dependencies = [
     "xlwt",
     "xmltodict>=0.13.0",
     "xxhash",
+    "zipp>=3.19.1",
 ]
 
 [project.optional-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,14 @@
 avro>=1.10.2
 chardet>=5.2.0
 click>=8.0.3
+dnspython>=2.6.1
 duckdb
 elasticsearch
 iterabledata
 jsonlines>=4.0.0
 lz4>=4.3.2
 mistql>=0.4.11
+numpy>=1.22.2
 openpyxl>=3.1.2
 orjson>=3.9.8
 pandas>=2.0.3
@@ -20,7 +22,7 @@ pyzstd
 qddate>=1.0.4
 requests
 rich>=13.6.0
-setuptools>=65.5.0
+setuptools>=70.0.0
 tabulate>=0.8.7
 tqdm
 typer
@@ -29,3 +31,4 @@ xlrd>=2.0.1
 xlwt
 xmltodict>=0.13.0
 xxhash
+zipp>=3.19.1


### PR DESCRIPTION
## Summary

- Consolidates the still-relevant fixes from the stale Snyk pull requests.
- Enforces safe lower bounds for `setuptools`, `dnspython`, `numpy`, and `zipp` in both package manifests.
- Records the dependency security remediation in the changelog.

## Why

The open Snyk pull requests are all conflicted against `master`, and several target removed legacy manifests. More importantly, the package and CI install from `pyproject.toml`; updating only the old PR diffs would not enforce the vulnerable minimum versions for package installs.

## Validation

- `git diff --check -- CHANGELOG.md pyproject.toml requirements.txt`
- `python -m build --wheel --no-isolation`

The remaining open Snyk pull requests can be closed as superseded by this PR.
